### PR TITLE
Actual dependencies listed in composer require

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,15 +12,13 @@
             "homepage": "http://php-and-symfony.matthiasnoback.nl"
         }
     ],
-    "require-dev": {
-        "phpunit/phpunit": ">=3.7",
-        "sebastian/exporter": "1.*"
-    },
     "autoload": {
         "psr-4" : { "Matthias\\SymfonyConfigTest\\" : "" }
     },
     "require": {
         "php": ">=5.3",
+        "phpunit/phpunit": ">=3.7",
+        "sebastian/exporter": "1.*",
         "symfony/config": "2.*"
     }
 }


### PR DESCRIPTION
Hi Matthias,

The dependencies on PHPUnit and SebastianBergmann\Exporter are mentioned in this packages source, not it's tests.

So I believe the dependencies should be set like in this PR to reflect reality.