### PR TITLE
move sebastian/exporter lib to require section

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,9 +12,11 @@
             "homepage": "http://php-and-symfony.matthiasnoback.nl"
         }
     ],
-    "require-dev": {
-        "phpunit/phpunit": ">=3.7",
+    "require": {
         "sebastian/exporter": "1.*"
+    },
+    "require-dev": {
+        "phpunit/phpunit": ">=3.7"
     },
     "autoload": {
         "psr-4" : { "Matthias\\SymfonyConfigTest\\" : "" }


### PR DESCRIPTION
Since the library is used in the `AbstractConfigurationConstraint`
class it must be included in the `require` section. Otherwise, it was
not usable in projects that did not require `sebastian/exporter`
themself.

This fixes #22.