### PR TITLE
Partially test below prototypes nodes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,36 +1,36 @@
 language: php
 
+sudo: false
+
 matrix:
   include:
+    - php: 7.0
+      env: SYMFONY_VERSION=2.3.*
+    - php: 7.0
+      env: SYMFONY_VERSION=2.7.*
+    - php: 7.0
+      env: SYMFONY_VERSION=2.8.*
+    - php: 7.0
+      env: SYMFONY_VERSION=3.0.*
+    - php: 7.0
+      env: SYMFONY_VERSION=3.1.*
+    - php: 7.0
+      env: PHPUNIT_VERSION=^4.0
     - php: 5.6
-      env: SYMFONY_VERSION=2.0.* PHPUNIT_VERSION=~4.0
-    - php: 5.6
-      env: SYMFONY_VERSION=2.1.* PHPUNIT_VERSION=~4.0
-    - php: 5.6
-      env: SYMFONY_VERSION=2.2.* PHPUNIT_VERSION=~4.0
-    - php: 5.6
-      env: SYMFONY_VERSION=2.3.* PHPUNIT_VERSION=~4.0
-    - php: 5.6
-      env: SYMFONY_VERSION=2.4.* PHPUNIT_VERSION=~4.0
-    - php: 5.6
-      env: SYMFONY_VERSION=2.5.* PHPUNIT_VERSION=~4.0
-    - php: 5.6
-      env: SYMFONY_VERSION=2.6.* PHPUNIT_VERSION=~4.0
-    - php: 5.6
-      env: SYMFONY_VERSION=2.6.* PHPUNIT_VERSION=~3.7
     - php: hhvm
-      env: SYMFONY_VERSION=2.6.* PHPUNIT_VERSION=~4.0
-    - php: 5.6
-      env: SYMFONY_VERSION=2.7.* PHPUNIT_VERSION=~4.0
-    - php: 5.6
-      env: SYMFONY_VERSION=2.8.*@dev PHPUNIT_VERSION=~4.0
-    - php: 5.6
-      env: SYMFONY_VERSION=3.0.*@dev PHPUNIT_VERSION=~4.0
 
-before_script:
-  - composer require --no-update "symfony/config:${SYMFONY_VERSION}"
-  - composer require --dev --no-update "phpunit/phpunit:${PHPUNIT_VERSION}"
-  - composer update
+cache:
+  directories:
+    - ~/.composer/cache/files
+
+before_install:
+  - phpenv config-rm xdebug.ini || true
+  - composer self-update
+
+install:
+  - if [ ! -z ${SYMFONY_VERSION+x} ]; then composer require --no-update "symfony/config:${SYMFONY_VERSION}"; fi
+  - if [ ! -z ${PHPUNIT_VERSION+x} ]; then composer require --no-update "phpunit/phpunit:${PHPUNIT_VERSION}"; fi
+  - composer update --prefer-dist
 
 notifications:
   email: matthiasnoback@gmail.com

--- a/Tests/Partial/PartialNodeTest.php
+++ b/Tests/Partial/PartialNodeTest.php
@@ -4,7 +4,9 @@ namespace Matthias\SymfonyConfigTest\Tests\Partial;
 
 use Matthias\SymfonyConfigTest\Partial\PartialNode;
 use Symfony\Component\Config\Definition\ArrayNode;
+use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\PrototypedArrayNode;
 
 class PartialNodeTest extends \PHPUnit_Framework_TestCase
 {
@@ -98,6 +100,38 @@ class PartialNodeTest extends \PHPUnit_Framework_TestCase
         PartialNode::excludeEverythingNotInPath($node, array('node_3'));
 
         $this->nodeOnlyHasChild($node, 'node_3');
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_crash_on_prototypes()
+    {
+        $treeBuilder = new TreeBuilder();
+        /** @var ArrayNodeDefinition $root */
+        $root = $treeBuilder->root('root');
+        $root
+            ->prototype('array')
+                ->children()
+                    ->arrayNode('node_1')
+                        ->children()
+                            ->scalarNode('node_1_scalar_node')->end()
+                        ->end()
+                    ->end()
+                    ->arrayNode('node_2')
+                        ->children()
+                            ->scalarNode('node_2_scalar_node')
+        ;
+
+        /** @var PrototypedArrayNode $node */
+        $node = $treeBuilder->buildTree();
+
+        /** @var ArrayNode $prototypeNode */
+        $prototypeNode = $node->getPrototype();
+
+        PartialNode::excludeEverythingNotInPath($node, array('*', 'node_1'));
+
+        $this->nodeOnlyHasChild($prototypeNode, 'node_1');
     }
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -13,12 +13,11 @@
         }
     ],
     "require": {
-        "php": ">=5.3",
-        "sebastian/exporter": "1.*",
-        "symfony/config": "~2.0|~3.0"
-    },
-    "require-dev": {
-        "phpunit/phpunit": ">=3.7"
+        "php": "^5.3|^7.0",
+
+        "phpunit/phpunit": "^4.0|^5.0",
+        "sebastian/exporter": "^1.0",
+        "symfony/config": "^2.3|^3.0"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,


### PR DESCRIPTION
Let's say I have the following configuration:

```yaml
collection:
  first_prototype:
    data1: "..."
    data2: "..."
  second_prototype:
    data1: "..."
    data2: "..."
```

And I want to test configuration definitions for `data1` and `data2` standalone (so adding an option below `data2` would not affect all the tests scenarios).

This PR allows for filtering out these nodes one by one with `collection.*.data1` and `collection.*.data2` syntax.