### PR TITLE
Move the phpunit dep to the require-dev section

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,9 +15,11 @@
     "require": {
         "php": "^5.3|^7.0",
 
-        "phpunit/phpunit": "^4.0|^5.0",
         "sebastian/exporter": "^1.0",
         "symfony/config": "^2.3|^3.0"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^4.0|^5.0"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,


### PR DESCRIPTION
Some packages choose to use a globally-installed phpunit, and things can
get messy when autoloading classes if there also is phpunit and its
dependencies installed via Composer.