### PR TITLE
Allow Symfony 4.0 in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     ],
     "require": {
         "php": "^7.0",
-        "symfony/config": "^2.3|^3.0"
+        "symfony/config": "^2.3 || ^3.0 || ^4.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.0"


### PR DESCRIPTION
This PR allows Symfony 4.0 on composer.json in preparation for the Symfony 4.0 release on Nov 30 2017: http://symfony.com/blog/helping-prepare-for-symfony-4-bundle-support