### PR TITLE
allow symfony 4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "php": "^5.3|^7.0",
 
         "sebastian/exporter": "^1.0|^2.0",
-        "symfony/config": "^2.3|^3.0"
+        "symfony/config": "^2.3|^3.0|^4.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.0|^5.0"


### PR DESCRIPTION
With this PR, we can require symfony 4.0 on packages where we require yours.
#SymfonyConHackday2017